### PR TITLE
Upgrade cli-clipboard version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 repository = "https://github.com/veeso/tui-realm-textarea"
 
 [dependencies]
-cli-clipboard = { version = "^0.2.1", optional = true }
+cli-clipboard = { version = "^0.4.0", optional = true }
 lazy-regex = "^2.3.0"
 tuirealm = { version = "^1.8.0", default-features = false, features = [ "derive" ]}
 tui-textarea = "^0.1.6"


### PR DESCRIPTION
# Upgrade cli-clipboard version

## Description

This upgrades to the latest `cli-clipboard` version, since the old one produces this compilation warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: nom v3.2.1, quick-xml v0.22.0
```

List here your changes

- Change version

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
