### PR TITLE
Don't show cursor if not in focus

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ use cli_clipboard::{ClipboardContext, ClipboardProvider};
 use tui_textarea::{CursorMove, TextArea as TextAreaWidget};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Borders, PropPayload, PropValue, Props, Style,
+    Alignment, AttrValue, Attribute, Borders, PropPayload, PropValue, Props, Style, TextModifiers,
 };
 use tuirealm::tui::layout::{Constraint, Direction as LayoutDirection, Layout, Rect};
 use tuirealm::tui::widgets::{Block, Paragraph};
@@ -410,6 +410,25 @@ impl<'a> MockComponent for TextArea<'a> {
                     .as_ref(),
                 )
                 .split(area);
+            
+            // Remove cursor if not in focus
+            let focus = self
+                .props
+                .get_or(Attribute::Focus, AttrValue::Flag(false))
+                .unwrap_flag();
+            if !focus {
+                self.widget.set_cursor_style(Style::reset());
+            } else {
+                let style = self
+                    .props
+                    .get_or(
+                        Attribute::Custom(TEXTAREA_CURSOR_STYLE),
+                        AttrValue::Style(Style::default().add_modifier(TextModifiers::REVERSED)),
+                    )
+                    .unwrap_style();
+                self.widget.set_cursor_style(style);
+            }
+
             // render widget
             frame.render_widget(self.widget.widget(), chunks[0]);
             if let Some(fmt) = self.status_fmt.as_ref() {


### PR DESCRIPTION
# Don't show cursor if not in focus

## Description

This hides the cursor if textarea is not in focus.

List here your changes

- If not in focus, the cursor style will be reset and set back if in focus again.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
