### PR TITLE
Multiline paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [1.1.2](#112)
   - [1.1.1](#111)
   - [1.1.0](#110)
   - [1.0.0](#100)
 
 ---
+
+## 1.1.2
+
+Released on 29/08/2023
+
+Thanks to @erak
+
+- Added support for multiline paste command. #5
 
 ## 1.1.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-realm-textarea"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Christian Visintin"]
 edition = "2021"
 categories = ["command-line-utilities"]
@@ -14,10 +14,12 @@ readme = "README.md"
 repository = "https://github.com/veeso/tui-realm-textarea"
 
 [dependencies]
-cli-clipboard = { version = "^0.2.1", optional = true }
-lazy-regex = "^2.3.0"
-tuirealm = { version = "^1.8.0", default-features = false, features = [ "derive" ]}
-tui-textarea = "^0.1.6"
+cli-clipboard = { version = "^0.4", optional = true }
+lazy-regex = "^3"
+tuirealm = { version = "^1.8.0", default-features = false, features = [
+  "derive",
+] }
+tui-textarea = "^0.2"
 
 [dev-dependencies]
 crossterm = "^0.25"
@@ -25,11 +27,11 @@ pretty_assertions = "^1.0.0"
 tui-realm-stdlib = "^1.1.6"
 
 [features]
-default = [ "with-crossterm" ]
-clipboard = [ "cli-clipboard" ]
-search = [ "tui-textarea/search" ]
-with-crossterm = [ "tuirealm/with-crossterm" ]
-with-termion = [ "tuirealm/with-termion" ]
+default = ["with-crossterm"]
+clipboard = ["cli-clipboard"]
+search = ["tui-textarea/search"]
+with-crossterm = ["tuirealm/with-crossterm"]
+with-termion = ["tuirealm/with-termion"]
 
 [[example]]
 name = "demo"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">Developed by <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
-<p align="center">Current version: 1.1.1 (17/10/2022)</p>
+<p align="center">Current version: 1.1.2 (29/08/2023)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,9 +385,14 @@ impl<'a> TextArea<'a> {
     fn paste(&mut self) {
         // get content from context
         if let Ok(Ok(yank)) = ClipboardContext::new().map(|mut ctx| ctx.get_contents()) {
-            self.widget.set_yank_text(yank);
-            self.widget.paste();
-            self.widget.set_yank_text(String::default());
+            // TODO: It's desired to set and paste yanked text, but pasting new lines as part of the yanked
+            // text is currently not supported by the textarea widget. Therefor, each line is inserted
+            // separately. The disadvantage of this workaround is, that each newly inserted line is a
+            // separate entry in the history and therefor a separate undo step.
+            for line in yank.lines() {
+                self.widget.insert_str(line);
+                self.widget.insert_newline();
+            }
         }
     }
 }


### PR DESCRIPTION
# Multiline paste

Pasting new lines as part of the yanked text is currently not supported by the tui-textarea widget. Since pasting text from the clipboard sets and pastes yanked text, the above adds a limitation that is removed with this workaround.

## Description

This workaround adds each line from the clipboard separately. The disadvantage of this is, that each newly inserted line is a separate entry in the history and therefor a separate undo step.

List here your changes

- Do not set and paste yanked text, but rather call `insert_str()` and `insert_newline()` separately.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
