### PR TITLE
Set margin of layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Press `ESC` to quit
 - `FocusStyle(Style)`: inactive style
 - `ScrollStep(Length)`: Defines the maximum amount of rows to scroll
 - `Title(Title)`: Set box title
+- `Custom($TEXTAREA_LAYOUT_MARGIN, Size)`: Set margin of layout
 
 ### Footer and status format
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ pub const TEXTAREA_SINGLE_LINE: &str = "single-line";
 pub const TEXTAREA_SEARCH_PATTERN: &str = "search-pattern";
 #[cfg(feature = "search")]
 pub const TEXTAREA_SEARCH_STYLE: &str = "search-style";
+pub const TEXTAREA_LAYOUT_MARGIN: &str = "layout-margin";
 
 // -- cmd
 pub const TEXTAREA_CMD_NEWLINE: &str = "0";
@@ -368,6 +369,15 @@ impl<'a> TextArea<'a> {
         self
     }
 
+    /// Set margin of layout
+    pub fn layout_margin(mut self, margin: u16) -> Self {
+        self.attr(
+            Attribute::Custom(TEXTAREA_LAYOUT_MARGIN),
+            AttrValue::Size(margin),
+        );
+        self
+    }
+
     // -- private
     fn get_block(&self) -> Option<Block<'a>> {
         let mut block = Block::default();
@@ -425,7 +435,9 @@ impl<'a> MockComponent for TextArea<'a> {
             if let Some(block) = self.get_block() {
                 self.widget.set_block(block);
             }
-            let margin = if self.get_block().is_some() { 1 } else { 0 };
+            let margin_prop = self.props.get_or(Attribute::Custom(TEXTAREA_LAYOUT_MARGIN), AttrValue::Size(1))
+                .unwrap_size();
+            let margin = if self.get_block().is_some() { margin_prop } else { 0 };
             // make chunks
             let chunks = Layout::default()
                 .direction(LayoutDirection::Vertical)


### PR DESCRIPTION
# Set Margin for Layout

This patch enables the ability to set the margin size of the layout.

## Description

- Introduced a new property: `Custom($TEXTAREA_LAYOUT_MARGIN, Size)`
- Add a `layout_margin` function to `impl<'a> TextArea<'a>`
- Modified the `view` function of `impl<'a> MockComponent for TextArea<'a>` to allow it to reference the margin settings.
- The default margin value is retained as `1`, ensuring backward compatibility.

Thank you for developing the awesome library!
I am currently developing [csvs](https://github.com/koma-private/csvs), a command-line tool that utilizes `tui-realm-textarea`.

While designing the layout for my application, I noticed there were unwanted spaces around the `TextArea` component. This misalignment prevented me from horizontally aligning the heights of the UI components, as illustrated in the attached image.

This PR introduces the ability to set the margin size, allowing for better control over layout design.

<img width="1451" alt="margin" src="https://github.com/user-attachments/assets/0b561e57-1498-40d4-adca-3012616b7e57" />

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist

- [X] My code follows the contribution guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I formatted the code with `cargo fmt`
- [X] I checked my code using `cargo clippy` and reports no warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have introduced no new *C-bindings*
- [X] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [X] I increased or maintained the code coverage for the project, compared to the previous commit
